### PR TITLE
fixed broken link to forum: from Tech Lead to QA Lead

### DIFF
--- a/handbook/workflows/qa-lead.md
+++ b/handbook/workflows/qa-lead.md
@@ -27,5 +27,5 @@ Members can propose to issue the `QA Lead` badge to any member who:
 * Knows the limits of their skills and how to identify expertise in others.
 
 {% hint style="info" %}
-View the [current list of QA Leads here](https://forum.dorg.tech/g/Tech-Lead)
+View the [current list of QA Leads here](https://forum.dorg.tech/g/QA-Lead)
 {% endhint %}


### PR DESCRIPTION
After the change of the forum badge from Tech Lead to QA Lead, the link broke.