### PR TITLE
fixed broken link to forum

### DIFF
--- a/handbook/workflows/coordination-lead.md
+++ b/handbook/workflows/coordination-lead.md
@@ -17,7 +17,7 @@ Members can propose to issue the `Coordination Lead` badge to any member who:
 * Has shadowed a `Coordination Lead` for at least one week on an ongoing client project.
 
 {% hint style="info" %}
-View the [current list of Coordination Leads here](https://forum.dorg.tech/g/Project-Manager)
+View the [current list of Coordination Leads here](https://forum.dorg.tech/g/Coord-Lead)
 {% endhint %}
 
 ## Project Management Workflows


### PR DESCRIPTION
After the change of the forum badge from Project Manager to Coordination Lead, the link broke.

(sorry for doing 2 PRs, one for each link - editing directly on GH)